### PR TITLE
Add support for specifying compression method when writing geotiffs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Changed
   is provided.
 - vis.pds.create_raw now creates .JSON output files by default instead of XML PDS4
   labels, but XML files can still be made.
+- carto.heatmap.write_geotiff_rasterio now supports compressed output and defaults to "deflate"
 
 
 Fixed

--- a/src/vipersci/carto/heatmap.py
+++ b/src/vipersci/carto/heatmap.py
@@ -330,6 +330,7 @@ def write_geotiff_rasterio(
     source_crs=None,
     nodata_value=0,
     profile={},
+    compress="deflate",
 ) -> Dict[str, Any]:
     """
     Writes 2D data to a geotiff file
@@ -346,6 +347,8 @@ def write_geotiff_rasterio(
         profile (dict): Additional profile data to use with rasterio.
             Will be merged / updated with basic information about the raster itself.
             Defaults to an empty dictionary (no additional data).
+        compress: Compression method to use if not specified in profile.  
+            Any value supported by GDAL - defaults to "deflate"
     Returns
         A dictionary that mimics the information provided by gdalinfo
     """
@@ -366,6 +369,9 @@ def write_geotiff_rasterio(
             "nodata": nodata_value,
         }
     )
+
+    if not "compress" in profile:
+        unified_profile.update(compress=compress)
 
     with rasterio.open(out_filepath, "w", **unified_profile) as raster:
         for i, d in enumerate(data, start=1):

--- a/src/vipersci/carto/heatmap.py
+++ b/src/vipersci/carto/heatmap.py
@@ -347,7 +347,7 @@ def write_geotiff_rasterio(
         profile (dict): Additional profile data to use with rasterio.
             Will be merged / updated with basic information about the raster itself.
             Defaults to an empty dictionary (no additional data).
-        compress: Compression method to use if not specified in profile.  
+        compress: Compression method to use if not specified in profile.
             Any value supported by GDAL - defaults to "deflate"
     Returns
         A dictionary that mimics the information provided by gdalinfo


### PR DESCRIPTION


## Description
Add a compression method parameter to the `write_geotiff_rasterio` helper method.  Default to the `deflate` method. 

Is this desired, or should we default to uncompressed output?

## Motivation and Context
A heatmap of a rover track is extremely sparse data.  An uncompressed high-resolution plot can be gigabytes but compress down 1000x to a few megabytes.

## How Has This Been Tested?
Manually tested with multiple datasets and compression methods.  All output files are valid.  

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/vipersci/blob/master/LICENSE).

- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the vipersci project uses, and I have submitted a CLA.

