### PR TITLE
Pano check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,8 @@ Added
   create_raw.py)
 - light_records.py which handles information about luminaire state.
 - anaglyph.py
+- pano_check.py to sort through image records and figure out what would be a good
+  panorama set.
 
 Changed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,10 @@ Changed
   labels.
 - create_vis_dbs entry point changed to vis_create_dbs to conform with other vis-related
   entry points.
+- pid.VISID now properly sorts the uncompressed "z" state lower (better) than the
+  lossless compressed "a" state.
+- pid.VISID now has a best_compression() function to sort out the best compression state
+  from an iterable containing may compression states from a single observation.
 
 
 0.5.0 (2023-07-26)

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - psycopg2
   - pyproj
   - rasterio
+  - requests
   - scikit-image
   - scikit-learn
   - shapely

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -19,4 +19,5 @@ dependencies:
   - sphinxcontrib-autoprogram
   - tox
   - types-pillow
+  - types-requests
   - twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ geopandas
 matplotlib
 numpy
 rasterio
+requests
 pandas
 pillow
 psycopg2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,5 +9,6 @@ Sphinx
 tox
 twine
 types-pillow
+types-requests
 wheel
 watchdog

--- a/src/vipersci/vis/db/image_records.py
+++ b/src/vipersci/vis/db/image_records.py
@@ -495,6 +495,12 @@ class ImageRecord(Base):
 
         return
 
+    def __lt__(self, other):
+        if isinstance(other, self.__class__):
+            return VISID(self.product_id) < VISID(other.product_id)
+        else:
+            return NotImplemented
+
     @hybrid_property
     def exposure_duration(self):
         return self._exposure_duration

--- a/src/vipersci/vis/pano_check.py
+++ b/src/vipersci/vis/pano_check.py
@@ -1,0 +1,274 @@
+"""Check to see if images could be made into a panorama.
+"""
+
+# Copyright 2023, United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reuse is permitted under the terms of the license.
+# The AUTHORS file and the LICENSE file are at the
+# top level of this library.
+
+import argparse
+from datetime import datetime, timezone
+from functools import partial
+import itertools
+import logging
+from pathlib import Path
+import sys
+
+import pandas as pd
+import requests
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from vipersci.vis.db.image_records import ImageRecord
+from vipersci.pds import pid as pds
+from vipersci import util
+
+logger = logging.getLogger(__name__)
+
+
+def arg_parser():
+    parser = argparse.ArgumentParser(
+        description=__doc__, parents=[util.parent_parser()]
+    )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        help="Path to CSV file with times and locations.  Ignored if --url is set."
+    )
+    parser.add_argument(
+        "-d",
+        "--dburl",
+        help="Database with an image_records table to read from. "
+        "If not given, no database will be written to.  Example: "
+        "postgresql://postgres:NotTheDefault@localhost/visdb",
+    )
+    parser.add_argument(
+        "-m",
+        "--mapserver",
+        help="URL that will respond to requests when given an event_time and "
+        "a crs_code."
+    )
+    parser.add_argument(
+        "-s",
+        "--since",
+        default=0,
+        help="An ISO8601 datetime after which should be searched for images "
+        "in the database."
+    )
+    parser.add_argument(
+        "-u",
+        "--until",
+        default=datetime.now(tz=timezone.utc),
+        help="An ISO8601 datetime before which should be searched for images "
+        "in the database."
+    )
+    parser.add_argument(
+        "--url",
+        help="URL to which event_times may be posted and for which location and "
+        "orientation will be returned."
+    )
+    parser.add_argument(
+        "--input",
+        nargs="*",
+        required=False,
+        help="VIS Image Record Product IDs."
+    )
+    return parser
+
+
+def main():
+    parser = arg_parser()
+    args = parser.parse_args()
+    util.set_logger(args.verbose)
+
+    gppf = None
+    if args.url is not None:
+        gppf = partial(get_position_and_pose_from_mapserver, url=args.url)
+    elif args.csv is not None:
+        gppf = partial(get_position_and_pose_from_df, path=args.csv)
+    else:
+        parser.error(
+            "Neither --url nor --csv were given.  Need at least one to be a "
+            "source for position and pose with time."
+        )
+
+    if args.input is not None:
+        pids = list(map(pds.VISID, args.input))
+        pano_groups = check(pids, gppf)
+
+    else:
+        t_since = datetime.fromisoformat(args.since)
+        t_until = datetime.fromisoformat(args.until)
+        if args.until < args.since:
+            parser.error(
+                f"The -s argument ({args.since}) must be less than the -u "
+                f"argument ({args.until})."
+            )
+        if args.dburl is None:
+            parser.error(
+                "To query images between times, you must enter a --dburl."
+            )
+
+        engine = create_engine(args.dburl)
+        with Session(engine) as session:
+            result = session.scalars(
+                select(ImageRecord).where(
+                    t_since <= ImageRecord.start_time,
+                    ImageRecord.start_time <= t_until
+                )
+            )
+            pano_groups = check(result, gppf)
+       
+    for pg in pano_groups:
+        print(f"For position and pose {pg[1]}:")
+        for p in pg[0]:
+            print(f"\t{p}")
+
+    return
+
+
+def check(images: list, get_pos_pose_func=None):
+    if get_pos_pose_func is None:
+        raise ValueError("A function must be provided to get_pos_pose_func.")
+    images.sort()
+    image_records_by_time = {}
+    times = []
+    for im in images:
+        if isinstance(im, ImageRecord):
+            ts = im.start_time.timestamp()
+        elif isinstance(im, pds.VISID):
+            ts = im.datetime().timestamp()
+        else:
+            raise TypeError(f"{im} is neither an ImageRecord nor a VISID.")
+        image_records_by_time[ts] = im
+        times.append(ts)
+
+    tpp = get_pos_pose_func(times)
+    grouped = groupby_2nd(tpp)
+
+    pano_groups = list()
+    for t_list, position_pose in grouped:
+        if len(t_list) > 1:
+            # We have a pano group
+            irs = [image_records_by_time[t] for t in t_list]
+            pano_groups.append((irs, position_pose))
+
+    return pano_groups
+
+
+def get_position_and_pose_from_df(
+        times: list,
+        path: Path,
+        time_column=0,
+        x_column=1,
+        y_column=2,
+        yaw_column=3,
+):
+    """
+    Given a list of times and a Path to a CSV file with the specified columns,
+    return a list of two-tuples whose first element is the time and whose
+    second element is an N-tuple of x-location, y-location, and yaw.
+
+    If None is given for any of the x-, y-, or yaw- columns, they are ignored
+    from the CSV read.
+    """
+    uc = list()
+    for c in (x_column, y_column, yaw_column):
+        if c is not None:
+            uc.append(c)
+
+    df = pd.read_csv(path, usecols=uc, parse_dates={"times": [time_column, ]})
+
+    tpp = list()
+    for t in times:
+        row = df.iloc[(df['time_column']-t).abs().argsort()[:1]]
+        tpp.append(t, row.tolist())
+
+    return tpp
+
+
+def get_position_and_pose_from_mapserver(
+        times: list,
+        url: str,
+        crs: str = "VIPER:910101"
+):
+    """
+    Given a list of times and a URL that requests can be made against,
+    return a list of two-tuples whose first element is the time and
+    whose second element is a three-tuple of x-location, y-location,
+    and yaw.
+    """
+
+    tpp = list()
+
+    for t in times:
+        position_result = requests.get(
+            url,
+            params={
+                "event_time": t,
+                "crs_code": crs,
+            }
+        )
+        rj = position_result.json()
+
+        tpp.append((t, (rj["location"][0], rj["location"][1], rj["yaw"])))
+
+    return tpp
+
+
+def groupby_2nd(
+    tuples: list,
+):
+    """
+    Given a list of sorted two-tuples, determine groupings based on the
+    second element of the two-tuple.
+
+    The returned list of two-tuples contains one "group" per element.  The
+    first element of the two tuple is the list of input first elements that have
+    the same input second element, and the second element of the two-tuple is the
+    input second element.
+
+    The list should be sorted by increasing order on the second element of the tuple.
+
+    For example::
+
+        t = [("Alice", "foo"), ("Bob", "bar"), ("Catherine", "bar")]
+        g = groupby_2nd(t)
+        print(g)
+        >>> [(["Alice",], "foo"), (["Bob", "Catherine"], "bar")]
+    """
+
+    def keyfunc(t: tuple):
+        return t[1]
+
+    grouped = list()
+    for k, g in itertools.groupby(tuples, key=keyfunc):
+        first = list()
+        second = ""
+        for elem in g:
+            first.append(elem[0])
+            second = elem[1]
+        grouped.append((first, second))
+
+    return grouped
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vipersci/vis/pano_check.py
+++ b/src/vipersci/vis/pano_check.py
@@ -164,11 +164,11 @@ def check(
     if all(map(isinstance, images, itertools.repeat(ImageRecord))):
         image_records = {}
         for im in images:
-            vid = pds.VISID(im.product_id)
+            vid = pds.VISID(im.product_id)  # type: ignore  # noqa
             image_records[vid] = im
             raw_vids.append(vid)
     elif all(map(isinstance, images, itertools.repeat(pds.VISID))):
-        raw_vids = images
+        raw_vids = list(images)  # type: ignore  # noqa
     else:
         raise TypeError(
             "The provided iterable does not contain all ImageRecords or "

--- a/tests/test_image_records.py
+++ b/tests/test_image_records.py
@@ -26,6 +26,7 @@
 from datetime import datetime, timedelta, timezone
 import unittest
 
+from vipersci.pds.pid import VISID
 from vipersci.vis.db import image_records as trp
 
 
@@ -153,6 +154,14 @@ class TestImageRecord(unittest.TestCase):
     # def test_purpose(self):
     #     rp = trp.ImageRecord(**self.d)
     #     self.assertRaises(ValueError, setattr, rp, "purpose", "dummy")
+
+    def test_lt(self):
+        ir1 = trp.ImageRecord(**self.d)
+        v = VISID("230127-000000-ncl-a")
+        ir2 = trp.ImageRecord(
+            product_id=str(v), start_time=v.datetime(), exposure_duration=111
+        )
+        self.assertTrue(ir1 < ir2)
 
     def test_update(self):
         rp = trp.ImageRecord(**self.d)

--- a/tests/test_pano_check.py
+++ b/tests/test_pano_check.py
@@ -9,16 +9,22 @@
 
 from argparse import ArgumentParser
 from datetime import datetime, timezone
+from functools import partial
+from pathlib import Path
 import unittest
 from unittest.mock import patch
 
+import pandas as pd
+
+from vipersci.pds import pid as pds
 from vipersci.vis import pano_check as pc
+from vipersci.vis.db.image_records import ImageRecord
 
 
 class TestFunctions(unittest.TestCase):
-    # def test_arg_parser(self):
-    #     p = pc.arg_parser()
-    #     self.assertIsInstance(p, ArgumentParser)
+    def test_arg_parser(self):
+        p = pc.arg_parser()
+        self.assertIsInstance(p, ArgumentParser)
 
     def test_groupby_2nd(self):
         tuples = [
@@ -27,7 +33,12 @@ class TestFunctions(unittest.TestCase):
             ("Catherine", "bar"),
         ]
         truth = [
-            (["Alice",], "foo"),
+            (
+                [
+                    "Alice",
+                ],
+                "foo",
+            ),
             (["Bob", "Catherine"], "bar"),
         ]
 
@@ -36,7 +47,6 @@ class TestFunctions(unittest.TestCase):
 
 
 class TestPositionAndPose(unittest.TestCase):
-
     def setUp(self):
         self.datetimes = (
             datetime(2024, 11, 27, 1, 2, 3, tzinfo=timezone.utc),
@@ -50,10 +60,18 @@ class TestPositionAndPose(unittest.TestCase):
         self.yaw = (0, 45, 90, 270)
 
         self.truth = [
-            (t, (x, y, yaw)) for t, x, y, yaw in zip(
-                self.times, self.x, self.y, self.yaw
-            )
+            (t, (x, y, yaw))
+            for t, x, y, yaw in zip(self.times, self.x, self.y, self.yaw)
         ]
+
+        self.df = pd.DataFrame(
+            data={
+                "c0": pd.Series(self.times),
+                "c1": pd.Series(self.x),
+                "c2": pd.Series(self.y),
+                "c3": pd.Series(self.yaw),
+            }
+        )
 
     def test_get_pp_from_mapserver(self):
         class req_dict(dict):
@@ -71,4 +89,57 @@ class TestPositionAndPose(unittest.TestCase):
             tpp = pc.get_position_and_pose_from_mapserver(self.times, url="foo")
             self.assertEqual(tpp, self.truth)
 
-    # def test_get_pp_from_df(self):
+    def test_get_pp_from_df(self):
+        my_times = self.times.copy()
+        my_times[0] += 10
+
+        my_truth = [
+            (t, (x, y, yaw)) for t, x, y, yaw in zip(my_times, self.x, self.y, self.yaw)
+        ]
+
+        with patch("vipersci.vis.pano_check.pd.read_csv", return_value=self.df):
+            tpp = pc.get_position_and_pose_from_df(my_times, Path("dummy.csv"))
+            self.assertEqual(tpp, my_truth)
+
+    def test_check(self):
+        pid_list = [
+            "241127-010203-ncl-a",
+            "241127-010303-ncl-a",
+            "241127-010403-ncl-a",
+            "241127-010403-ncr-s",
+            "241128-010203-ncl-a",
+            "241130-010203-ncl-a",
+            "241130-010303-ncl-a",
+        ]
+        pds.VISID(pid_list[0])
+        pids = list(map(pds.VISID, pid_list))
+
+        self.assertRaises(ValueError, pc.check, pids)
+
+        im_recs = list()
+        for x in pids:
+            im_recs.append(
+                ImageRecord(
+                    product_id=str(x), start_time=x.datetime(), exposure_duration=111
+                )
+            )
+
+        # Only two groups in the above pid_list
+        truth = [
+            (pids[0:3], (self.x[0], self.y[0], self.yaw[0])),
+            (pids[-2:], (self.x[3], self.y[3], self.yaw[3])),
+        ]
+
+        self.assertRaises(TypeError, pc.check, pid_list, "dummy_function")
+
+        with patch("vipersci.vis.pano_check.pd.read_csv", return_value=self.df):
+            gffp = partial(pc.get_position_and_pose_from_df, path="dummy.csv")
+            p_groups = pc.check(pids, gffp)
+            self.assertEqual(p_groups, truth)
+
+            im_groups = pc.check(im_recs, gffp)
+            pid_groups = list()
+            for im_list, pose in im_groups:
+                pid_list = list(map(pds.VISID, [x.product_id for x in im_list]))
+                pid_groups.append((pid_list, pose))
+            self.assertEqual(pid_groups, truth)

--- a/tests/test_pano_check.py
+++ b/tests/test_pano_check.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""This module has tests for the vis.pano-check functions."""
+
+# Copyright 2023, vipersci developers.
+#
+# Reuse is permitted under the terms of the license.
+# The AUTHORS file and the LICENSE file are at the
+# top level of this library.
+
+from argparse import ArgumentParser
+from datetime import datetime, timezone
+import unittest
+from unittest.mock import patch
+
+from vipersci.vis import pano_check as pc
+
+
+class TestFunctions(unittest.TestCase):
+    # def test_arg_parser(self):
+    #     p = pc.arg_parser()
+    #     self.assertIsInstance(p, ArgumentParser)
+
+    def test_groupby_2nd(self):
+        tuples = [
+            ("Alice", "foo"),
+            ("Bob", "bar"),
+            ("Catherine", "bar"),
+        ]
+        truth = [
+            (["Alice",], "foo"),
+            (["Bob", "Catherine"], "bar"),
+        ]
+
+        grouped = pc.groupby_2nd(tuples)
+        self.assertEqual(truth, grouped)
+
+
+class TestPositionAndPose(unittest.TestCase):
+
+    def setUp(self):
+        self.datetimes = (
+            datetime(2024, 11, 27, 1, 2, 3, tzinfo=timezone.utc),
+            datetime(2024, 11, 28, 1, 2, 3, tzinfo=timezone.utc),
+            datetime(2024, 11, 29, 1, 2, 3, tzinfo=timezone.utc),
+            datetime(2024, 11, 30, 1, 2, 3, tzinfo=timezone.utc),
+        )
+        self.times = [x.timestamp() for x in self.datetimes]
+        self.x = (-1, 2, 3, 4)
+        self.y = (-1, 2, 3, 4)
+        self.yaw = (0, 45, 90, 270)
+
+        self.truth = [
+            (t, (x, y, yaw)) for t, x, y, yaw in zip(
+                self.times, self.x, self.y, self.yaw
+            )
+        ]
+
+    def test_get_pp_from_mapserver(self):
+        class req_dict(dict):
+            def json(self):
+                return self
+
+        time_d = {}
+        for t, x, y, yaw in zip(self.times, self.x, self.y, self.yaw):
+            time_d[t] = req_dict(location=(x, y), yaw=yaw)
+
+        def requests_get_se(url, params):
+            return time_d[params["event_time"]]
+
+        with patch("vipersci.vis.pano_check.requests.get", side_effect=requests_get_se):
+            tpp = pc.get_position_and_pose_from_mapserver(self.times, url="foo")
+            self.assertEqual(tpp, self.truth)
+
+    # def test_get_pp_from_df(self):

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -260,13 +260,14 @@ class TestVISID(unittest.TestCase):
         self.assertEqual(sorted(vids), [vid0, vid1, vid2, vid3, vid4])
 
     def test_best_compression(self):
-        truth = [
-            "241127-010203-ncl-a", "241127-010204-ncr-z"
-        ]
+        truth = ["241127-010203-ncl-a", "241127-010204-ncr-z"]
 
         test = [
-            "241127-010203-ncl-a", "241127-010203-ncl-d", "241127-010203-ncl-s",
-            "241127-010204-ncr-z", "241127-010204-ncr-s"
+            "241127-010203-ncl-a",
+            "241127-010203-ncl-d",
+            "241127-010203-ncl-s",
+            "241127-010204-ncr-z",
+            "241127-010204-ncr-s",
         ]
         result = pid.VISID.best_compression(test)
         self.assertEqual(result, truth)

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -246,16 +246,30 @@ class TestVISID(unittest.TestCase):
         self.assertEqual("VISID('220117-010101-ncl-a')", repr(cid))
 
     def test_lt(self):
+        vid0 = pid.VISID("220117-010101-ncl-z")
         vid1 = pid.VISID("220117-010101-ncl-a")
         vid2 = pid.VISID("220117-010101-ncl-b")
         vid3 = pid.VISID("220117-010101-ncl-c")
         vid4 = pid.VISID("220117-010101-ncl-d")
+        self.assertTrue(vid0 < vid1)
         self.assertTrue(vid1 < vid2)
         self.assertTrue(vid2 < vid3)
         self.assertTrue(vid3 < vid4)
 
-        vids = [vid3, vid4, vid1, vid2]
-        self.assertEqual(sorted(vids), [vid1, vid2, vid3, vid4])
+        vids = [vid3, vid4, vid1, vid2, vid0]
+        self.assertEqual(sorted(vids), [vid0, vid1, vid2, vid3, vid4])
+
+    def test_best_compression(self):
+        truth = [
+            "241127-010203-ncl-a", "241127-010204-ncr-z"
+        ]
+
+        test = [
+            "241127-010203-ncl-a", "241127-010203-ncl-d", "241127-010203-ncl-s",
+            "241127-010204-ncr-z", "241127-010204-ncr-s"
+        ]
+        result = pid.VISID.best_compression(test)
+        self.assertEqual(result, truth)
 
 
 class TestPanoID(unittest.TestCase):


### PR DESCRIPTION
Added initial mechanism to find "pano groups" which are defined as all images taken from the same rover position and pose.  Naturally this requires a source of position and pose information.

Also fixed "sorting" for the ultra-rare uncompressed (z) image.


## Types of changes
<!--- What types of changes does your code introduce? Remove lines that do not apply: -->
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/vipersci/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the vipersci project uses, and I have submitted a CLA.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/NeoGeographyToolkit/vipersci/blob/master/AUTHORS.rst) file, if you haven't already. -->

<!-- Thanks for contributing to vipersci! -->
