### PR TITLE
Build9 modifications

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,8 @@ Fixed
   out.
 - nss_simulator.py, when asked to produce an output set of maps, uses a zero nodata value
   rather than whatever nodata value was present in the input burial depth map.
+- anaglyph.py needed some minor changes to align with upcoming changes in the
+  scikit-image architecture.
 
 
 0.6.0 (2023-09-25)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,13 @@ and the release date, in year-month-day format (see examples below).
 Unreleased
 ----------
 
+Fixed
+^^^^^
+- validators.validate_dateimte_asutc now properly raises a ValueError if the provided
+  tz-aware datetime has a non-UTC tz offset (before any tz-aware datetime would pass
+  the validator).
+
+
 0.6.0 (2023-09-25)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Fixed
 - validators.validate_dateimte_asutc now properly raises a ValueError if the provided
   tz-aware datetime has a non-UTC tz offset (before any tz-aware datetime would pass
   the validator).
+- image_records.ImageRecord object now has pgaGain instead of ppaGain (which was surely
+  a typo in the early upstream data.
 
 
 0.6.0 (2023-09-25)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,10 @@ Fixed
   the validator).
 - image_records.ImageRecord object now has pgaGain instead of ppaGain (which was surely
   a typo in the early upstream data.
+- create_image.py now correctly imports all of the tables that have a relation to the
+  image_records table so that SQLAlchemy can properly resolve them, and downstream
+  users of the create_image.create() function don't need to worry about sorting that
+  out.
 
 
 0.6.0 (2023-09-25)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,8 @@ Fixed
   image_records table so that SQLAlchemy can properly resolve them, and downstream
   users of the create_image.create() function don't need to worry about sorting that
   out.
+- nss_simulator.py, when asked to produce an output set of maps, uses a zero nodata value
+  rather than whatever nodata value was present in the input burial depth map.
 
 
 0.6.0 (2023-09-25)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1-dev
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/src/vipersci/__init__.py
+++ b/src/vipersci/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """vipersci Developers"""
 __email__ = "rbeyer@seti.org"
-__version__ = "0.6.0"
+__version__ = "0.6.1-dev"

--- a/src/vipersci/carto/nss_simulator.py
+++ b/src/vipersci/carto/nss_simulator.py
@@ -182,6 +182,7 @@ def main():
         d2_arr = d2.reshape(bd_data.shape)
 
         kwds = bd_data.profile
+        kwds["nodata"] = 0.0
         write_tif(args.output, "_d1.tif", d1_arr, kwds)
         write_tif(args.output, "_d2.tif", d2_arr, kwds)
         return

--- a/src/vipersci/vis/anaglyph.py
+++ b/src/vipersci/vis/anaglyph.py
@@ -164,9 +164,9 @@ def correlate_and_shift(left: NDArray, right: NDArray) -> NDArray:
     function with performs the correlation, and then shifts the array.
     """
     shift = tuple(
-        phase_cross_correlation(
-            left, right, return_error="always", normalization=None
-        )[0].astype(int)
+        phase_cross_correlation(left, right, return_error="always", normalization=None)[
+            0
+        ].astype(int)
     )
     logger.info(f"Right image shift: {shift}")
     return np.roll(right, shift, (0, 1))

--- a/src/vipersci/vis/anaglyph.py
+++ b/src/vipersci/vis/anaglyph.py
@@ -165,8 +165,8 @@ def correlate_and_shift(left: NDArray, right: NDArray) -> NDArray:
     """
     shift = tuple(
         phase_cross_correlation(
-            left, right, return_error=False, normalization=None
-        ).astype(int)
+            left, right, return_error="always", normalization=None
+        )[0].astype(int)
     )
     logger.info(f"Right image shift: {shift}")
     return np.roll(right, shift, (0, 1))

--- a/src/vipersci/vis/create_image.py
+++ b/src/vipersci/vis/create_image.py
@@ -49,6 +49,9 @@ from tifftools import read_tiff
 
 import vipersci
 from vipersci.vis.db.image_records import ImageRecord
+from vipersci.vis.db.image_requests import ImageRequest  # noqa
+from vipersci.vis.db.junc_image_record_tags import JuncImageRecordTag  # noqa
+from vipersci.vis.db.junc_image_req_ldst import JuncImageRequestLDST  # noqa
 from vipersci.pds import pid as pds
 from vipersci import util
 

--- a/src/vipersci/vis/db/image_records.py
+++ b/src/vipersci/vis/db/image_records.py
@@ -245,7 +245,7 @@ class ImageRecord(Base):
         doc="The translated floating point multiplier derived from PGA_GAIN "
         "from the MCSE Image Header.",
     )
-    ppaGain = synonym("pga_gain")  # Surely, this is a Yamcs typo, should be pgaGain
+    pgaGain = synonym("pga_gain")
     processing_info = mapped_column(
         Integer,
         nullable=False,

--- a/src/vipersci/vis/db/validators.py
+++ b/src/vipersci/vis/db/validators.py
@@ -25,7 +25,7 @@
 # The AUTHORS file and the LICENSE file are at the
 # top level of this library.
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from vipersci.pds.datetime import fromisozformat
 
@@ -34,6 +34,8 @@ def validate_datetime_asutc(key, value):
     if isinstance(value, datetime):
         if value.utcoffset() is None:
             raise ValueError(f"{key} must be tz aware.")
+        elif value.utcoffset() != timedelta():
+            raise ValueError(f"{key} must be tz aware with a UTC offset.")
         dt = value
     elif isinstance(value, str):
         if value.endswith("Z"):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -23,7 +23,7 @@
 # The AUTHORS file and the LICENSE file are at the
 # top level of this library.
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 import unittest
 
 from vipersci.pds.datetime import fromisozformat
@@ -46,6 +46,9 @@ class TestValidators(unittest.TestCase):
 
         dt_e = datetime(2022, 1, 27, 0, 0, 0)
         self.assertRaises(ValueError, vld.validate_datetime_asutc, "foo", dt_e)
+
+        dt_offset = datetime(2022, 1, 27, 0, 0, 0, tzinfo=timezone(timedelta(hours=2)))
+        self.assertRaises(ValueError, vld.validate_datetime_asutc, "foo", dt_offset)
 
         self.assertRaises(
             ValueError,


### PR DESCRIPTION
These are primarily bug-fixes related to SQLAlchemy table relations, but there are also some miscellaneous fixes.

## Description
- validators.validate_dateimte_asutc now properly raises a ValueError if the provided tz-aware datetime has a non-UTC tz offset (before any tz-aware datetime would pass the validator).
- image_records.ImageRecord object now has pgaGain instead of ppaGain (which was surely a typo in the early upstream data.
- create_image.py now correctly imports all of the tables that have a relation to the image_records table so that SQLAlchemy can properly resolve them, and downstream users of the create_image.create() function don't need to worry about sorting that out.
- nss_simulator.py, when asked to produce an output set of maps, uses a zero nodata value rather than whatever nodata value was present in the input burial depth map.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/vipersci/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the vipersci project uses, and I have submitted a CLA.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/NeoGeographyToolkit/vipersci/blob/master/AUTHORS.rst) file, if you haven't already. -->

<!-- Thanks for contributing to vipersci! -->
