### PR TITLE
Better name handling and Pano thumbnails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,8 @@ Changed
 ^^^^^^^
 - The instrument_name() function in pid.py now can deal with alias names that are
   within a given string, not just an exact match.
-
+- Now that pid.instrument_name() is more robust, ImageRecord.__init__() can handle a
+  wider variety of Yamcs parameter names, should they change in the future.
 
 0.7.0 (2023-02-05)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,9 @@ Changed
   within a given string, not just an exact match.
 - Now that pid.instrument_name() is more robust, ImageRecord.__init__() can handle a
   wider variety of Yamcs parameter names, should they change in the future.
+- create_mmgis_pano.py - create() now takes a thumbsize int or tuple of ints that
+  will control the creation and size of an output thumbnail JPG file, with naming
+  convention set by Yamcs/OpenMCT.
 
 0.7.0 (2023-02-05)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,12 @@ and the release date, in year-month-day format (see examples below).
 Unreleased
 ----------
 
+Changed
+^^^^^^^
+- The instrument_name() function in pid.py now can deal with alias names that are
+  within a given string, not just an exact match.
+
+
 0.7.0 (2023-02-05)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.8.0-dev
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/src/vipersci/__init__.py
+++ b/src/vipersci/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """vipersci Developers"""
 __email__ = "rbeyer@seti.org"
-__version__ = "0.7.0"
+__version__ = "0.8.0-dev"

--- a/src/vipersci/pds/pid.py
+++ b/src/vipersci/pds/pid.py
@@ -365,7 +365,13 @@ class VISID(VIPERID):
         elif name.casefold() in vis_instrument_aliases:
             return vis_instruments[vis_instrument_aliases[name.casefold()]]
         else:
-            raise ValueError(f"No VIS instrument name based on {name} could be found.")
+            for k in vis_instrument_aliases.keys():
+                if k in name.casefold():
+                    return vis_instruments[vis_instrument_aliases[k]]
+            else:
+                raise ValueError(
+                    f"No VIS instrument name based on {name} could be found."
+                )
 
     def compression_class(self):
         """Returns text value for the PDS onboard_compression_class."""

--- a/src/vipersci/vis/db/image_records.py
+++ b/src/vipersci/vis/db/image_records.py
@@ -386,11 +386,9 @@ class ImageRecord(Base):
         if "instrument_name" in kwargs:
             self.instrument_name = VISID.instrument_name(self.instrument_name)
         elif "yamcs_name" in kwargs:
-            maybe_name = self.yamcs_name.split("/")[-1].replace("_", " ")
-            if maybe_name.endswith((" icer", " jpeg", " slog")):
-                maybe_name = maybe_name[:-5]
-
-            self.instrument_name = VISID.instrument_name(maybe_name)
+            self.instrument_name = VISID.instrument_name(
+                self.yamcs_name.split("/")[-1].replace("_", " ")
+            )
 
         if "cameraId" in otherargs:
             if VISID.instrument_name(otherargs["cameraId"]) != self.instrument_name:

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -259,6 +259,9 @@ class TestVISID(unittest.TestCase):
         vids = [vid3, vid4, vid1, vid2, vid0]
         self.assertEqual(sorted(vids), [vid0, vid1, vid2, vid3, vid4])
 
+    def test_instrument_name(self):
+        self.assertEqual("NavCam Left", pid.VISID.instrument_name("navcam left orig"))
+
     def test_best_compression(self):
         truth = ["241127-010203-ncl-a", "241127-010204-ncr-z"]
 


### PR DESCRIPTION
- The instrument_name() function in pid.py now can deal with alias names that are within a given string, not just an exact match.
- Now that pid.instrument_name() is more robust, ImageRecord.__init__() can handle a wider variety of Yamcs parameter names, should they change in the future.
- create_mmgis_pano.py - create() now takes a thumbsize int or tuple of ints that will control the creation and size of an output thumbnail JPG file, with naming convention set by Yamcs/OpenMCT.


## Types of changes
<!--- What types of changes does your code introduce? Remove lines that do not apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and remove lines that do not apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- I have added tests to cover my changes.
- All new and existing tests passed.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/vipersci/blob/master/LICENSE).

<!-- Remove the statement that does not apply. -->
- I claim copyrights on my contributions in this pull request, and I provide those contributions via this pull request under the same license terms that the vipersci project uses, and I have submitted a CLA.

<!-- No matter how you contributed, please make sure you add your name to the
[AUTHORS](https://github.com/NeoGeographyToolkit/vipersci/blob/master/AUTHORS.rst) file, if you haven't already. -->

<!-- Thanks for contributing to vipersci! -->
