### PR TITLE
use d1 and d2 when calculating the weh_arr for nss

### DIFF
--- a/src/vipersci/nss.py
+++ b/src/vipersci/nss.py
@@ -167,7 +167,7 @@ class DataModeler:
             np.column_stack((d1.compressed(), d2.compressed()))
         )
         weh_arr[~d1.mask] = self.det2_model(
-            np.column_stack((d2.compressed(), d2.compressed()))
+            np.column_stack((d1.compressed(), d2.compressed()))
         )
         uweh_arr = uniform_weh(
             d1.filled(self.fill_value), fill_value=self.fill_value, bounds_error=False


### PR DESCRIPTION

## Description
We noticed that the WEH dry over wet was never rendering anything, and this is because the value was always off the edge of the model.  When looking at the code it looks like it was incorrectly using the y value twice.

## Licensing:

This project is released under the [LICENSE](https://github.com/NeoGeographyToolkit/vipersci/blob/master/LICENSE).

